### PR TITLE
Check whether alpha information is present- then drop it (with a warning).

### DIFF
--- a/R/colourInput.R
+++ b/R/colourInput.R
@@ -225,15 +225,21 @@ formatHEXsingle <- function(x) {
     stop(sprintf("%s is not a valid colour", x), call. = FALSE)
   }
 
-  # check whether it is 6-digit hex code with alpha.
-  if (substr(x, 1, 1) == "#" && nchar(x) == 9) {
-    x <- substr(x, 1, 7)
-    warning("colourpicker does not support colours with transparency. Alpha channel information dropped.")
-  }
-
   # ensure x begins with a pound sign
   if (substr(x, 1, 1) != "#") {
     x <- paste0("#", x)
+  }
+
+  # check whether it is 6-digit hex code with alpha.
+  if (nchar(x) == 9) {
+    x <- substr(x, 1, 7)
+    warning("colourpicker does not support colours with transparency. Alpha channel information dropped.", call. = FALSE)
+  }
+
+  # check whether it is 3-digit hex code with alpha.
+  if (nchar(x) == 5) {
+    x <- substr(x, 1, 4)
+    warning("colourpicker does not support colours with transparency. Alpha channel information dropped.", call. = FALSE)
   }
 
   # expand x to a 6-character HEX colour if it's in shortform

--- a/R/colourInput.R
+++ b/R/colourInput.R
@@ -221,8 +221,14 @@ formatHEXsingle <- function(x) {
   if (x %in% grDevices::colors()) {
     x <- do.call(grDevices::rgb, as.list(grDevices::col2rgb(x) / 255))
   }
-  if (!grepl("^#?([[:xdigit:]]{3}|[[:xdigit:]]{6})$", x)) {
+  if (!grepl("^#?([[:xdigit:]]{3}|[[:xdigit:]]{6}|[[:xdigit:]]{8})$", x)) {
     stop(sprintf("%s is not a valid colour", x), call. = FALSE)
+  }
+
+  # check whether it is 6-digit hex code with alpha.
+  if (substr(x, 1, 1) == "#" && nchar(x) == 9) {
+    x <- substr(x, 1, 7)
+    warning("colourpicker does not support colours with transparency. Alpha channel information dropped.")
   }
 
   # ensure x begins with a pound sign


### PR DESCRIPTION
This tries to fix [#4](https://github.com/daattali/colourpicker/issues/4). Basically I let 8 digit colors pass as valid, then checks and drops the last two digits with a warning.