### PR TITLE
Added support for restoring shiny state

### DIFF
--- a/R/colourInput.R
+++ b/R/colourInput.R
@@ -93,6 +93,8 @@ colourInput <- function(inputId, label, value = "white",
   showColour <- match.arg(showColour)
   palette <- match.arg(palette)
 
+  value <- restoreInput(id = inputId, default = value)
+
   # declare dependencies
   shiny::addResourcePath("colourpicker-binding",
                          system.file("srcjs", package = "colourpicker"))


### PR DESCRIPTION
Added support for restoring shiny state. Tested with the following app code:

```r
library(shiny)
library(colourpicker)

# Define UI for application that draws a histogram
ui <- function(restore) { fluidPage(

   # Application title
   titlePanel("Old Faithful Geyser Data"),

   # Sidebar with a slider input for number of bins
   sidebarLayout(
      sidebarPanel(
         sliderInput("bins",
                     "Number of bins:",
                     min = 1,
                     max = 50,
                     value = 30),
         colourInput('bincolour', 'Colour', value = 'red'),
         bookmarkButton()
      ),

      # Show a plot of the generated distribution
      mainPanel(
         plotOutput("distPlot")
      )
   )
)}

# Define server logic required to draw a histogram
server <- function(input, output) {

   output$distPlot <- renderPlot({
      # generate bins based on input$bins from ui.R
      x    <- faithful[, 2]
      bins <- seq(min(x), max(x), length.out = input$bins + 1)

      # draw the histogram with the specified number of bins
      hist(x, breaks = bins, col = input$bincolour, border = 'white')
   })
}

# Run the application
shinyApp(ui = ui, server = server, enableBookmarking = 'url')
```